### PR TITLE
Add copyright of the original pre-commit to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2024 j178
+Copyright (c) 2014 pre-commit dev team: Anthony Sottile, Ken Struys
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Thanks @asottile for pointing out that I actually violated the MIT license—my apologies for that!

Based on [this answer](https://opensource.stackexchange.com/a/5488), I think we can consolidate the original copyright statement into a single LICENSE file. I hope I'm doing it correctly.