### PR TITLE
refactor: revert #107 but using `enum_dispatch`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equator"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,6 +1534,7 @@ dependencies = [
  "clap_complete",
  "ctrlc",
  "dunce",
+ "enum_dispatch",
  "etcetera",
  "fancy-regex",
  "fs-err",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ clap = { version = "4.5.16", features = ["derive", "env"] }
 clap_complete = "4.5.37"
 ctrlc = "3.4.5"
 dunce = "1.0.5"
+enum_dispatch = "0.3.13"
 fancy-regex = "0.14.0"
 fs-err = "2.11.0"
 fs2 = "0.4.3"

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -15,6 +15,7 @@ use crate::config::Stage;
 use crate::fs::{normalize_path, Simplified};
 use crate::git;
 use crate::hook::{Hook, Project};
+use crate::languages::LanguageImpl;
 use crate::printer::Printer;
 use crate::run::{run_hooks, FilenameFilter, WorkTreeKeeper};
 use crate::store::Store;

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -13,10 +13,10 @@ use url::Url;
 
 use crate::config::{
     self, read_config, read_manifest, ConfigLocalHook, ConfigRemoteHook, ConfigRepo, ConfigWire,
-    Language, ManifestHook, Stage, CONFIG_FILE, MANIFEST_FILE,
+    ManifestHook, Stage, CONFIG_FILE, MANIFEST_FILE,
 };
 use crate::fs::{Simplified, CWD};
-use crate::languages::DEFAULT_VERSION;
+use crate::languages::{Language, LanguageImpl, DEFAULT_VERSION};
 use crate::printer::Printer;
 use crate::store::Store;
 use crate::warn_user;
@@ -340,7 +340,8 @@ impl HookBuilder {
                 .and_then(|v| v.get(&language).cloned());
         }
         if self.config.language_version.is_none() {
-            self.config.language_version = Some(language.default_version().to_string());
+            self.config.language_version =
+                Some(Language::from(language).default_version().to_string());
         }
 
         if self.config.stages.is_none() {
@@ -374,7 +375,7 @@ impl HookBuilder {
     /// Check the hook configuration.
     fn check(&self) {
         let language = self.config.language;
-        if language.environment_dir().is_none() {
+        if Language::from(language).environment_dir().is_none() {
             if self.config.language_version != Some(DEFAULT_VERSION.to_string()) {
                 warn_user!(
                     "Language {} does not need environment, but language_version is set",
@@ -402,7 +403,7 @@ impl HookBuilder {
             id: self.config.id,
             name: self.config.name,
             entry: self.config.entry,
-            language: self.config.language,
+            language: self.config.language.into(),
             alias: self.config.alias.expect("alias not set"),
             files: self.config.files,
             exclude: self.config.exclude,

--- a/src/run.rs
+++ b/src/run.rs
@@ -25,6 +25,7 @@ use crate::git;
 use crate::git::{get_diff, git_cmd, GIT};
 use crate::hook::Hook;
 use crate::identify::tags_from_path;
+use crate::languages::LanguageImpl;
 use crate::printer::Printer;
 use crate::store::Store;
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -10,6 +10,7 @@ use crate::config::ConfigRemoteRepo;
 use crate::fs::{copy_dir_all, LockedFile};
 use crate::git::clone_repo;
 use crate::hook::{Hook, Repo};
+use crate::languages::LanguageImpl;
 use crate::printer::Printer;
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
hi, @j178 , IMHO I think using [enum_dispatch](https://docs.rs/enum_dispatch/latest/enum_dispatch/) to remove boilerplate code much better, PTAL